### PR TITLE
allow user to cancel generate password

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -7,7 +7,10 @@ var generatePassword = function() {
   // Window Prompts
   debugger;
   let promptLength = window.prompt("Please choose how long you want your password to be. A minimum of 8 characters and a maximum of 128.");
-  if (parseInt(promptLength) >= 8 && parseInt(promptLength) <= 128) {
+   if (promptLength === null) {
+    return null
+  }
+   else if (parseInt(promptLength) >= 8 && parseInt(promptLength) <= 128) {
     promptLength = Math.floor(promptLength);
   } else if (parseInt(promptLength) < 8) {
     window.alert("Your password needs to be a minimum of 8 characters!");


### PR DESCRIPTION
Hey!  Love the app, I was trying it out and realized I couldn't cancel the password generating process if I clicked cancel on the first dialog box where it says, "Please choose how long you want your password to be. A minimum of 8 characters and a maximum of 128."  Now if the user clicks the cancel button on the first prompt, they are just returned to the main app screen.  It's no longer an infinite loop of telling the user they need to have a numeric value for the first prompt.  Again, very cool app!